### PR TITLE
Add nickname command implementation and related functionality

### DIFF
--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -67,7 +67,12 @@ public:
     const std::string& getUsername() const;
     const std::string& getRealName() const  ; 
     void addMsg(std::string msg);   
-    int getClientFd() const; 
+    int getClientFd() const;   
+    void setNickName(std::string&  nick ) ;     
+    std::string  getNickName( ) 
+    {  
+        return _Nick ;   
+    }
 };
 
 #endif

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -47,7 +47,8 @@ class  Server: public IEventHandler
           static Server&  getInstance() ;
           void beReady2Send() { 
                _ready2Send = true  ;  
-          } ;       
+          } ;         
+          bool isNickAvai(std::string nick)  ;    
           bool isReady(){ return _ready2Send  ;   } ;   
           static void initServer(int port, const std::string& password);   
           ~Server() ;    

--- a/include/commandFactory.hpp
+++ b/include/commandFactory.hpp
@@ -6,6 +6,7 @@
 #include "PrivmsgCommand.hpp"
 #include "QuitCommand.hpp"
 #include "PingCommand.hpp"
+#include "nickCommand.hpp"
 #include "PongCommand.hpp"
 
 class commandFactory {  

--- a/include/nickCommand.hpp
+++ b/include/nickCommand.hpp
@@ -1,0 +1,10 @@
+#include "Command.hpp"  
+#include "channelCommand.hpp"
+
+
+class nickCommand : public Command  {  
+    public : 
+            nickCommand() {} ;  
+            ~nickCommand(){} ;   
+          void execute(Client  &cl ,    std::map<std::string ,  std::string >&params )   ;   
+}  ;   

--- a/src/Client/Client.cpp
+++ b/src/Client/Client.cpp
@@ -123,6 +123,10 @@ void  Client::userCommand(Command  & cmd  , std::map<std::string ,  std::string 
     return(Server::getInstance().AddChannel(chName));   
 }   
 
+void Client::setNickName(std::string &   nick  ) 
+ { 
+    _Nick = nick ;        
+ }
 void Client::addMsg(std::string msg) {   
 if (msg.length() < 2 || msg.compare(msg.length() - 2, 2, "\r\n") != 0) {
     msg += "\r\n";
@@ -141,7 +145,6 @@ void Client::handle_event(epoll_event e)
         ssize_t n = recv(_client_fd, (void *)buffer.data(), buffer.size(), 0);
         
         if (n > 0) {  
-            std::cout << "RAW string: " << buffer.data() << std::endl;
             _messageBuffer.append(buffer.data(), n);
             size_t pos;
             while ((pos = _messageBuffer.find("\r\n")) != std::string::npos) {

--- a/src/commandFactory/commandFactory.cpp
+++ b/src/commandFactory/commandFactory.cpp
@@ -22,6 +22,8 @@ Command* commandFactory::makeCommand(std::string  command )
         else if(command == "PING")
             return new PingCommand() ;
         else if(command == "PONG")
-            return new PongCommand() ;
+            return new PongCommand() ;  
+        else if(command == "NICK")
+            return new nickCommand() ;    
         return NULL ;    
 } ;  

--- a/src/nickCommand/nickCommand.cpp
+++ b/src/nickCommand/nickCommand.cpp
@@ -1,0 +1,46 @@
+#include "nickCommand.hpp" 
+#include "Server.hpp"
+#include "severResponsFactory.hpp"
+    
+
+void nickCommand::execute(Client &cl,   std::map<std::string, std::string> &params)
+{  
+    if (!params.count("nickname") || params["nickname"].empty())
+    {
+        cl.addMsg(serverResponseFactory::getResp(431, cl, params)); 
+        return;
+    }
+
+    std::string newNick = params["nickname"];
+
+    if (cl.getNickName() == newNick)
+    {
+        return;
+    }
+
+    if (!Server::getInstance().isNickAvai(newNick))
+    {
+        cl.addMsg(serverResponseFactory::getResp(433, cl, params)); 
+        return;
+    }
+
+    if (newNick.size() < 1 || newNick.size() > 9)
+    {
+        cl.addMsg(serverResponseFactory::getResp(432, cl, params)); 
+        return;
+    }
+    if (newNick.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-[]\\`^{}_") != std::string::npos)
+    {
+        cl.addMsg(serverResponseFactory::getResp(432, cl, params));
+        return;
+    }
+
+    if (!isalpha(newNick[0]) && std::string("-[]\\`^{}_").find(newNick[0]) == std::string::npos)
+    {
+        cl.addMsg(serverResponseFactory::getResp(432, cl, params));
+        return;
+    }
+
+    cl.setNickName(newNick);
+
+}

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -121,9 +121,18 @@ void Server::handle_event(epoll_event ev)
         delete client;  // Clean up on error
         throw e;
     }
-}  
+}   
 
-  Client&  Server::getUser(std::string nickname )   
+bool Server::isNickAvai(std::string  nick   )  
+{ 
+		for(std::vector<Client *>::iterator it = _clientList.begin(); it != _clientList.end(); it++)  
+	{ 
+		  if((*it)->userData()["nickname"] == nick)  
+			  return false ;  
+	}  ;       
+	return true  ;   
+} 
+Client&  Server::getUser(std::string nickname )   
 {  
 	for(std::vector<Client *>::iterator it = _clientList.begin(); it != _clientList.end(); it++)  
 	{ 


### PR DESCRIPTION
- Introduced  class to handle nickname changes.
- Added  and  methods in  class.
- Implemented nickname availability check in  class.
- Updated  to create  instances.

Implements NICK command

Adds the NICK command functionality, allowing clients to change their nicknames.

Introduces nickname availability checks to prevent conflicts and enforces nickname constraints such as length and allowed characters. Returns appropriate error messages to the client when nickname changes fail.