### PR TITLE
Updates JOIN command parameter handling

### DIFF
--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -270,7 +270,7 @@ if (cmd == "JOIN") {
         for (size_t i = 0; i < channels.size(); ++i) {
             params["channel_" + i ] = channels[i];
             if (i < keys.size()) {
-                params["password_" + i ] = keys[i];
+                params["key_" + i ] = keys[i];
             }
         }
     }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -385,7 +385,8 @@ void Server::callCommand(std::string& cmd, std::map<std::string, std::string>& p
 				{  
 				for(int i  =  0  ;  i  <   atoi(params["count"].c_str()) ;  i++ )   
 					{   
-						params["channel"]  =  params["channel_"+i]  ;   
+						params["channel"]  =  params["channel_"+i]  ;  
+						params["key"] =  params["key_"+i] ;      
 						if (params.find("channel") != params.end()) {
 							Channel  *  target = sender.getChannel(params["channel"])      ;     
 							if(!target  &&     cmd  == "JOIN")  


### PR DESCRIPTION
Ensures the JOIN command correctly handles keys
associated with multiple channels. It renames
the password parameter to key for clarity and
consistency and ensures the key is correctly
This pull request updates the handling of channel keys in the JOIN command logic to use a more consistent parameter naming convention. The changes ensure that channel keys are stored and accessed using the `"key_"` prefix instead of `"password_"`, which improves clarity and consistency across the codebase.

**JOIN command parameter handling:**

* Updated the parameter name from `"password_"` to `"key_"` when storing channel keys in the `params` map in `Parser.cpp`.
* Updated the logic in `server.cpp` to retrieve channel keys using the `"key_"` prefix when processing JOIN commands.
passed to the channel when joining.